### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout/file_dialog_main.xml
+++ b/app/src/main/res/layout/file_dialog_main.xml
@@ -1,66 +1,97 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout android:id="@+id/relativeLayout01"
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	android:orientation="vertical" android:layout_width="fill_parent"
-	android:layout_height="fill_parent">
+<?xml version='1.0' encoding='utf-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/relativeLayout01"
+  android:orientation="vertical"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent">
 
-	<LinearLayout android:id="@+id/fdLinearLayoutList"
-		android:orientation="vertical" android:layout_width="fill_parent"
-		android:layout_height="wrap_content" android:layout_alignParentBottom="true">
+  <LinearLayout android:id="@+id/fdLinearLayoutList"
+    android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:layout_alignParentBottom="true">
 
-		<LinearLayout android:id="@+id/fdLinearLayoutSelect"
-			android:orientation="vertical" android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:layout_alignParentBottom="true" android:paddingLeft="10dp"
-			android:paddingRight="10dp" android:paddingBottom="5dp">
+    <LinearLayout android:id="@+id/fdLinearLayoutSelect"
+      android:orientation="vertical"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:paddingLeft="10dp"
+      android:paddingRight="10dp"
+      android:paddingBottom="5dp">
 
-			<LinearLayout android:orientation="horizontal"
-				android:layout_width="fill_parent" android:layout_height="fill_parent">
-				<Button android:id="@+id/fdButtonNew" android:layout_height="wrap_content"
-					android:layout_width="0dip" android:layout_weight=".3"
-					android:text="@string/nnew"></Button>
-				<Button android:id="@+id/fdButtonSelect" android:layout_height="wrap_content"
-					android:layout_width="0dip" android:layout_weight=".7"
-					android:text="@string/select"></Button>
-			</LinearLayout>
-		</LinearLayout>
+      <LinearLayout android:orientation="horizontal"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
 
-		<LinearLayout android:id="@+id/fdLinearLayoutCreate"
-			android:orientation="vertical" android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:layout_alignParentBottom="true" android:paddingLeft="10dp"
-			android:paddingRight="10dp" android:paddingBottom="5dp">
-			<TextView android:id="@+id/textViewFilename" android:text="@string/file_name"
-				android:layout_width="fill_parent" android:layout_height="wrap_content" />
-			<EditText android:text="" android:id="@+id/fdEditTextFile"
-				android:layout_width="fill_parent" android:layout_height="wrap_content"></EditText>
+        <Button android:id="@+id/fdButtonNew"
+          android:layout_height="wrap_content"
+          android:layout_width="0dip"
+          android:layout_weight=".3"
+          android:text="@string/nnew"/>
 
-			<LinearLayout android:orientation="horizontal"
-				android:layout_width="fill_parent" android:layout_height="fill_parent">
-				<Button android:id="@+id/fdButtonCancel" android:layout_height="wrap_content"
-					android:layout_width="0dip" android:layout_weight=".3"
-					android:text="@string/cancel"></Button>
-				<Button android:id="@+id/fdButtonCreate" android:layout_height="wrap_content"
-					android:layout_width="0dip" android:layout_weight=".7"
-					android:text="@string/create"></Button>
-			</LinearLayout>
-		</LinearLayout>
+        <Button android:id="@+id/fdButtonSelect"
+          android:layout_height="wrap_content"
+          android:layout_width="0dip"
+          android:layout_weight=".7"
+          android:text="@string/select"/>
+      </LinearLayout>
+      <!--Removed ObsoleteLayoutParam: layout_alignParentBottom-->
+    </LinearLayout>
 
-	</LinearLayout>
+    <LinearLayout android:id="@+id/fdLinearLayoutCreate"
+      android:orientation="vertical"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:paddingLeft="10dp"
+      android:paddingRight="10dp"
+      android:paddingBottom="5dp">
 
-	<LinearLayout android:orientation="vertical"
-		android:layout_width="fill_parent" android:layout_height="fill_parent"
-		android:layout_above="@+id/fdLinearLayoutList">
-		<TextView android:id="@+id/path" android:layout_width="fill_parent"
-			android:layout_height="wrap_content" />
-		<ListView android:id="@android:id/list" android:layout_width="fill_parent"
-			android:layout_height="fill_parent" />
-		<TextView android:id="@android:id/empty"
-			android:layout_width="fill_parent" android:layout_height="fill_parent"
-			android:text="@string/no_data" />
-	</LinearLayout>
+      <TextView android:id="@+id/textViewFilename"
+        android:text="@string/file_name"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"/>
 
+      <EditText android:text=""
+        android:id="@+id/fdEditTextFile"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"/>
 
+      <LinearLayout android:orientation="horizontal"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
 
+        <Button android:id="@+id/fdButtonCancel"
+          android:layout_height="wrap_content"
+          android:layout_width="0dip"
+          android:layout_weight=".3"
+          android:text="@string/cancel"/>
 
+        <Button android:id="@+id/fdButtonCreate"
+          android:layout_height="wrap_content"
+          android:layout_width="0dip"
+          android:layout_weight=".7"
+          android:text="@string/create"/>
+      </LinearLayout>
+      <!--Removed ObsoleteLayoutParam: layout_alignParentBottom-->
+    </LinearLayout>
+  </LinearLayout>
+
+  <LinearLayout android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_above="@+id/fdLinearLayoutList">
+
+    <TextView android:id="@+id/path"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"/>
+
+    <ListView android:id="@android:id/list"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"/>
+
+    <TextView android:id="@android:id/empty"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:text="@string/no_data"/>
+  </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/selected_area_info_top_row.xml
+++ b/app/src/main/res/layout/selected_area_info_top_row.xml
@@ -1,174 +1,194 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="300dp"
-    android:layout_height="wrap_content"
-    android:orientation="vertical" >
+<?xml version='1.0' encoding='utf-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="300dp"
+  android:layout_height="wrap_content"
+  android:orientation="vertical">
 
-    <TableLayout
+  <TableLayout android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:shrinkColumns="1">
+
+    <TableRow android:id="@+id/tableRow1"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+      <TextView android:id="@+id/totalTimeLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Total Time:"
+        android:textColor="@android:color/white"/>
+
+      <TextView android:id="@+id/totalTime"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="6 hours"
+        android:layout_marginLeft="5dp"
+        android:textColor="@android:color/white"/>
+    </TableRow>
+
+    <TableRow android:id="@+id/tableRow1"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+      <TextView android:id="@+id/totalDistLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Total Dist:"
+        android:textColor="@android:color/white"/>
+
+      <TextView android:id="@+id/totalDist"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:shrinkColumns="1"
-        android:layout_below="@+id/linearLayout1" >
+        android:text="25 miles"
+        android:layout_marginLeft="5dp"
+        android:textColor="@android:color/white"/>
+    </TableRow>
 
-        <TableRow
-            android:id="@+id/tableRow1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" >
+    <TableRow android:id="@+id/tableRow1"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
 
-            <TextView
-                android:id="@+id/totalTimeLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Total Time:"
-                android:textColor="@android:color/white" />
+      <TextView android:id="@+id/timesInAreaLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Times in area:"
+        android:textColor="@android:color/white"/>
 
-            <TextView
-                android:id="@+id/totalTime"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="6 hours"
-                android:layout_marginLeft="5dp"
-                android:textColor="@android:color/white" />
-        </TableRow>
+      <TextView android:id="@+id/timesInArea"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="20"
+        android:layout_marginLeft="5dp"
+        android:textColor="@android:color/white"/>
+    </TableRow>
+    <!--
 
-        <TableRow
-            android:id="@+id/tableRow1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" >
-
-            <TextView
-                android:id="@+id/totalDistLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Total Dist:"
-                android:textColor="@android:color/white" />
-
-            <TextView
-                android:id="@+id/totalDist"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="25 miles"
-                android:layout_marginLeft="5dp"
-                android:textColor="@android:color/white" />
-        </TableRow>
-
-        <TableRow
-            android:id="@+id/tableRow1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" >
-
-            <TextView
-                android:id="@+id/timesInAreaLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Times in area:"
-                android:textColor="@android:color/white" />
-
-            <TextView
-                android:id="@+id/timesInArea"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="20"
-                android:layout_marginLeft="5dp"
-                android:textColor="@android:color/white" />
-        </TableRow>
-
-        <!--
            <TableRow
+
             android:id="@+id/tableRow1"
+
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" >
+
+            android:layout_height="wrap_content"
+              >
+              
 
             <TextView
+
                 android:id="@+id/firstStartTimeLabel"
+
                 android:layout_width="match_parent"
+
                 android:layout_height="wrap_content"
+
                 android:text="Earliest in Area:"
-                android:textColor="@android:color/white" />
+
+                android:textColor="@android:color/white"
+                  />
+                  
 
             <TextView
+
                 android:id="@+id/firstStartTime"
+
                 android:layout_width="match_parent"
+
                 android:layout_height="wrap_content"
+
                 android:text="2012, Jan 31st, Wed, 12:00 AM"
-                android:textColor="@android:color/white" />
+
+                android:textColor="@android:color/white"
+                  />
         </TableRow>
+          
 
         <TableRow
+
             android:id="@+id/tableRow1"
+
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" >
+
+            android:layout_height="wrap_content"
+              >
+              
 
             <TextView
+
                 android:id="@+id/lastEndTimeLabel"
+
                 android:layout_width="match_parent"
+
                 android:layout_height="wrap_content"
+
                 android:text="Latest in Area:"
-                android:textColor="@android:color/white" />
+
+                android:textColor="@android:color/white"
+                  />
+                  
 
             <TextView
+
                 android:id="@+id/endTime"
+
                 android:layout_width="match_parent"
+
                 android:layout_height="wrap_content"
+
                 android:text="2012, Feb 31st, Wed, 12:00 PM "
-                android:textColor="@android:color/white" />
+
+                android:textColor="@android:color/white"
+                  />
         </TableRow>
+
         -->
 
-        <TableRow
-            android:id="@+id/timeZoneTableRow"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" >
+    <TableRow android:id="@+id/timeZoneTableRow"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
 
-            <TextView
-                android:id="@+id/timezoneLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Time Zone:"
-                android:textColor="@android:color/white" />
-
-            <TextView
-                android:id="@+id/timezone"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="America/Los Angeles"
-                android:layout_marginLeft="5dp"
-                android:textColor="@android:color/white" />
-        </TableRow>
-    </TableLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
+      <TextView android:id="@+id/timezoneLabel"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-        android:orientation="horizontal" >
+        android:text="Time Zone:"
+        android:textColor="@android:color/white"/>
 
-            <TextView
-                android:id="@+id/startTime"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight=".4"
-                android:text="@string/start_time"
-                android:textColor="@android:color/white" />
+      <TextView android:id="@+id/timezone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="America/Los Angeles"
+        android:layout_marginLeft="5dp"
+        android:textColor="@android:color/white"/>
+    </TableRow>
+    <!--Removed ObsoleteLayoutParam: layout_alignParentLeft-->
+    <!--Removed ObsoleteLayoutParam: layout_below-->
+  </TableLayout>
 
-            <TextView
-                android:id="@+id/endTime"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight=".4"
-		        android:layout_marginLeft="3dp"
-                android:text="@string/end_time"
-                android:textColor="@android:color/white" />
+  <LinearLayout android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="5dp"
+    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/distance"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-		        android:layout_marginLeft="3dp"
-                android:layout_weight=".2"
-                android:text="@string/dist"
-                android:textColor="@android:color/white" />
-        </LinearLayout>
+    <TextView android:id="@+id/startTime"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight=".4"
+      android:text="@string/start_time"
+      android:textColor="@android:color/white"/>
 
+    <TextView android:id="@+id/endTime"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight=".4"
+      android:layout_marginLeft="3dp"
+      android:text="@string/end_time"
+      android:textColor="@android:color/white"/>
+
+    <TextView android:id="@+id/distance"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_marginLeft="3dp"
+      android:layout_weight=".2"
+      android:text="@string/dist"
+      android:textColor="@android:color/white"/>
+  </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Hi (again),

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis