### PR TITLE
Fix crash from issue #57

### DIFF
--- a/app/src/main/java/com/rareventure/gps2/reviewer/map/MediaLocTimeMap.java
+++ b/app/src/main/java/com/rareventure/gps2/reviewer/map/MediaLocTimeMap.java
@@ -383,6 +383,8 @@ public class MediaLocTimeMap {
 							
 						} catch (IOException e1) {
 							Log.d(GTG.TAG,"No exif data for image "+data);
+						} catch (NegativeArraySizeException e2) {
+							Log.d(GTG.TAG,"Exif init error for image "+data);
 						}
 						
 					}


### PR DESCRIPTION
This fix is needed to handle an Android's platform API crash in the Exif reader. It has been fixed upstream but not all devices will be updated.